### PR TITLE
ENH: perform multi-event relocation by cluster

### DIFF
--- a/apps/scrtdd/hdd/clustering.h
+++ b/apps/scrtdd/hdd/clustering.h
@@ -23,6 +23,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <set>
+#include <list>
+#include <deque>
 
 
 namespace Seiscomp {
@@ -104,7 +106,7 @@ selectNeighbouringEvents(const CatalogCPtr& catalog,
                          double maxEllipsoidSize=10,
                          bool keepUnmatched=false);
 
-std::list<NeighboursPtr>
+std::deque< std::list<NeighboursPtr> >
 selectNeighbouringEventsCatalog(const CatalogCPtr& catalog,
                                 double minPhaseWeight,
                                 double minESdis,
@@ -117,6 +119,9 @@ selectNeighbouringEventsCatalog(const CatalogCPtr& catalog,
                                 unsigned numEllipsoids,
                                 double maxEllipsoidSize,
                                 bool keepUnmatched);
+
+std::deque< std::list<NeighboursPtr> >
+clusterizeNeighbouringEvents(const std::list<NeighboursPtr>& neighboursList);
 
 }
 }


### PR DESCRIPTION
Instead of relocating all events in one go each cluster is relocated
independently. This results in improved solutions since the parameters
of the solver are treted by cluster (e.g. residual downweighting)
Also each cluster covers a smaller area, which helps in avoiding breaking
the solver assumption of an euclidean geometry