### PR TITLE
Avoid FE_INVALID to be set

### DIFF
--- a/apps/scrtdd/hdd/waveform.cpp
+++ b/apps/scrtdd/hdd/waveform.cpp
@@ -554,7 +554,7 @@ bool xcorr(const GenericRecordCPtr &tr1,
 
     const double coeff = (n * sumSL - sumS * sumL) / (denomS * denomL);
 
-    if (std::abs(coeff) > std::abs(coeffOut) || !std::isfinite(coeffOut))
+    if (!std::isfinite(coeffOut) || std::abs(coeff) > std::abs(coeffOut))
     {
       coeffOut = coeff;
       delayOut = delay / freq; // samples to secs


### PR DESCRIPTION
Prevent the `FE_INVALID` flag (from `<cfenv>`) from being set. Comparison between a floating-point number and a `NaN` value might cause the flag to be set.

See also: 
- http://www.cplusplus.com/reference/cfenv/
- https://stackoverflow.com/q/54571977/12083893