### PR TITLE
Correctly set the waveform starttime

### DIFF
--- a/libs/hdd/waveform.cpp
+++ b/libs/hdd/waveform.cpp
@@ -265,7 +265,8 @@ bool trim(GenericRecord &trace, const Core::TimeWindow &tw)
 
   ArrayPtr sliced = trace.data()->slice(ofs, ofs + samples);
 
-  trace.setStartTime(tw.startTime());
+  trace.setStartTime(trace.startTime() +
+                     Core::TimeSpan(ofs / trace.samplingFrequency()));
   trace.setData(sliced.get());
 
   return true;


### PR DESCRIPTION
**Bugfix**:
- Correctly set the waveform starttime when trimming