### PR TITLE
Do not load config module

### DIFF
--- a/apps/scrtdd/rtdd.cpp
+++ b/apps/scrtdd/rtdd.cpp
@@ -259,7 +259,6 @@ RTDD::RTDD(int argc, char **argv) : Application(argc, argv)
   setInterpretNotifierEnabled(true);
 
   setLoadInventoryEnabled(true);
-  setLoadConfigModuleEnabled(true);
 
   setPrimaryMessagingGroup("LOCATION");
 


### PR DESCRIPTION
**Changes**:
- Do not load the config module. AFAIU, `scrtdd` does not make use from bindings, anyway.