### PR TITLE
Do not inherit global bindings

### DIFF
--- a/apps/scrtdd/descriptions/scrtdd.xml
+++ b/apps/scrtdd/descriptions/scrtdd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <seiscomp>
-  <module name="scrtdd" category="Processing" inherit-global-bindings="true">
+  <module name="scrtdd" category="Processing" inherit-global-bindings="false">
     <description>
       Double-Difference relocation module for real-time and catalogs relocation.
       Please see https://github.com/swiss-seismological-service/scrtdd for the documentation.


### PR DESCRIPTION
`scrtdd` does not make use of bindings, anyway.